### PR TITLE
bug fix for Song #artist_name setter

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -6,7 +6,7 @@ class Song < ActiveRecord::Base
   end
 
   def artist_name=(name)
-    artist = Artist.find_or_create_by(name: name)
+    artist = Artist.find_or_create_by(name: name) if !name.blank?
     self.artist = artist
   end
 end


### PR DESCRIPTION
The provided #display_artist method is dependent upon a song's artist attribute being **nil** if a song was created without an artist name in the new form. This means that the Song #artist_name setter that is tied to the form input should not create an Artist object if the input value is blank.